### PR TITLE
Updated for PHP 7 compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,14 @@ in ```src/NodeVisitor```). To test them, you should create a subfolder in ```tes
 folder and put a ```.test``` file in it. ```.test``` files have multiple sections separated by
 `-----`:
 
-1. First section is the description of the test suite. Can also contain PHP version constraint.
-2. Second section is the php code to be tested. It must be syntactically correct. 
-3. Third section is a newline (```\n```) separated array of messages that all the checkers
- should emit for the code from the previous section. If there should be no messages, just
- leave a blank like in this section. Please keep in mind that test suites are not isolated,
- so you may get messages from other checkers in your test suite.
+1. First section is the description of the test suite. It can also contain PHP version constraint.
+2. Second section is the php code to be tested. It must be syntactically correct, unless it is an expression
+ or a statement that had been correct in PHP 5 but is no longer correct in PHP 7. 
+3. Third section is a newline separated array of messages and errors that
+ should be emitted for the code from the previous section. Errors are instances of 
+ \Exception and \ParseException that are thrown during the checks. If there should be no messages
+ and no errors, just leave a blank like in this section. Please keep in mind that test suites are
+ not isolated, so you may get messages from other checkers in your test suite.
 
 Second and third sections can be repeated one or more times. 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ To run php7cc, you need php installed, minimum required version is 5.3.3. Requir
  the language features that are used in the code. For example, if traits are used
  somewhere in the checked code, you'll need PHP 5.4 or higher.
  
+PHP 7 is also supported, but files with syntax errors (for example, invalid numeric literals
+ or invalid UTF-8 codepoint escape sequences) can't be processed. You will only get the
+ message about the first syntax error for such files.
+ 
 You also need [composer](https://getcomposer.org/) to install php7cc.
 
 #### Installation

--- a/src/AbstractBaseMessage.php
+++ b/src/AbstractBaseMessage.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Sstalle\php7cc;
+
+abstract class AbstractBaseMessage
+{
+    /**
+     * @var string
+     */
+    protected $rawText;
+
+    /**
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * @var int
+     */
+    protected $line;
+
+    /**
+     * @param string   $text
+     * @param int|null $line
+     */
+    public function __construct($text, $line = null)
+    {
+        $this->rawText = $text;
+        $this->line = $line;
+        $this->text = $this->generateText();
+    }
+
+    /**
+     * @return string
+     */
+    public function getRawText()
+    {
+        return $this->rawText;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLine()
+    {
+        return $this->line;
+    }
+
+    abstract protected function generateText();
+}

--- a/src/CLIResultPrinter.php
+++ b/src/CLIResultPrinter.php
@@ -59,7 +59,7 @@ class CLIResultPrinter implements ResultPrinterInterface
         }
 
         foreach ($context->getErrors() as $error) {
-            $this->output->writeln($error->getMessage());
+            $this->output->writeln($error->getText());
         }
 
         $this->output->writeln('');

--- a/src/CompatibilityViolation/Message.php
+++ b/src/CompatibilityViolation/Message.php
@@ -3,64 +3,24 @@
 namespace Sstalle\php7cc\CompatibilityViolation;
 
 use PhpParser\Node;
+use Sstalle\php7cc\AbstractBaseMessage;
 
-class Message
+class Message extends AbstractBaseMessage
 {
-    /**
-     * @var string
-     */
-    protected $rawText;
-
-    /**
-     * @var string
-     */
-    protected $text;
-
-    /**
-     * @var int
-     */
-    protected $line;
-
     /**
      * @var Node[]
      */
     protected $nodes;
 
     /**
-     * @param string $text
-     * @param int    $line
-     * @param Node[] $nodes
+     * @param string   $text
+     * @param int|null $line
+     * @param Node[]   $nodes
      */
-    public function __construct($text, $line, array $nodes)
+    public function __construct($text, $line = null, array $nodes = array())
     {
-        $this->rawText = $text;
-        $this->line = $line;
+        parent::__construct($text, $line);
         $this->nodes = $nodes;
-        $this->text = $this->generateText();
-    }
-
-    /**
-     * @return string
-     */
-    public function getRawText()
-    {
-        return $this->rawText;
-    }
-
-    /**
-     * @return string
-     */
-    public function getText()
-    {
-        return $this->text;
-    }
-
-    /**
-     * @return int
-     */
-    public function getLine()
-    {
-        return $this->line;
     }
 
     /**

--- a/src/ContextChecker.php
+++ b/src/ContextChecker.php
@@ -49,7 +49,9 @@ class ContextChecker
             $parsedStatements = $this->parser->parse($context->getCheckedCode());
             $this->traverser->traverse($parsedStatements, $context, $this->lexer->getTokens());
         } catch (\Exception $e) {
-            $context->addError(new CheckError($e));
+            $context->addError(new CheckError($e->getMessage()));
+        } catch (\ParseException $e) {
+            $context->addError(new CheckError($e->getMessage(), $e->getLine()));
         }
     }
 }

--- a/src/Error/CheckError.php
+++ b/src/Error/CheckError.php
@@ -2,26 +2,17 @@
 
 namespace Sstalle\php7cc\Error;
 
-class CheckError
+use Sstalle\php7cc\AbstractBaseMessage;
+
+class CheckError extends AbstractBaseMessage
 {
-    /**
-     * @var \Exception
-     */
-    protected $wrappedException;
-
-    /**
-     * @param \Exception $wrappedException
-     */
-    public function __construct(\Exception $wrappedException)
+    protected function generateText()
     {
-        $this->wrappedException = $wrappedException;
-    }
+        $text = $this->getRawText();
+        if ($this->getLine()) {
+            $text = sprintf('Line %d. %s', $this->getLine(), $text);
+        }
 
-    /**
-     * @return string
-     */
-    public function getMessage()
-    {
-        return $this->wrappedException->getMessage();
+        return $text . '. Processing aborted.';
     }
 }

--- a/test/code/ContextCheckerTest.php
+++ b/test/code/ContextCheckerTest.php
@@ -55,10 +55,12 @@ class ContextCheckerTest extends \PHPUnit_Framework_TestCase
         $context = new \Sstalle\php7cc\CompatibilityViolation\StringContext($code, 'test');
         $contextChecker->checkContext($context);
         $expectedMessageCount = count($expectedMessages);
-        $actualMessageCount = count($context->getMessages());
+        $actualMessages = array_merge($context->getMessages(), $context->getErrors());
+        $actualMessageCount = count($actualMessages);
         $this->assertEquals($expectedMessageCount, $actualMessageCount, $name);
         if ($expectedMessageCount == $actualMessageCount) {
-            foreach ($context->getMessages() as $i => $message) {
+            /** @var \Sstalle\php7cc\AbstractBaseMessage $message */
+            foreach ($actualMessages as $i => $message) {
                 $this->assertEquals(
                     $this->canonicalize($expectedMessages[$i]),
                     $this->canonicalize($message->getRawText()),

--- a/test/resource/escapedUnicodeCodepoint/php5/escapedUnicodeCodepointInHeredoc.test
+++ b/test/resource/escapedUnicodeCodepoint/php5/escapedUnicodeCodepointInHeredoc.test
@@ -1,0 +1,25 @@
+Escaped unicode codepoints in heredoc
+PHP <7.0
+-----
+<?php
+$str = <<<EOD
+    \u{xyz}
+EOD;
+
+-----
+Unicode codepoint escaping "\u{xyz}" in a string
+-----
+<?php
+$str = <<<EOD
+    \\u{xyz}
+EOD;
+
+-----
+
+-----
+<?php
+$str = <<<EOD
+    \u202e
+EOD;
+
+-----

--- a/test/resource/escapedUnicodeCodepoint/php5/escapedUnicodeCodepointInString.test
+++ b/test/resource/escapedUnicodeCodepoint/php5/escapedUnicodeCodepointInString.test
@@ -1,4 +1,5 @@
 Escaped unicode codepoints in double quoted string
+PHP <7.0
 -----
 <?php $str = "\u{xyz}";
 -----

--- a/test/resource/escapedUnicodeCodepoint/php7/escapedUnicodeCodepointInHeredoc.test
+++ b/test/resource/escapedUnicodeCodepoint/php7/escapedUnicodeCodepointInHeredoc.test
@@ -1,4 +1,5 @@
 Escaped unicode codepoints in heredoc
+PHP >=7.0
 -----
 <?php
 $str = <<<EOD
@@ -6,7 +7,7 @@ $str = <<<EOD
 EOD;
 
 -----
-Unicode codepoint escaping "\u{xyz}" in a string
+Invalid UTF-8 codepoint escape sequence
 -----
 <?php
 $str = <<<EOD

--- a/test/resource/escapedUnicodeCodepoint/php7/escapedUnicodeCodepointInString.test
+++ b/test/resource/escapedUnicodeCodepoint/php7/escapedUnicodeCodepointInString.test
@@ -1,0 +1,25 @@
+Escaped unicode codepoints in double quoted string
+PHP >=7.0
+-----
+<?php $str = "\u{xyz}";
+-----
+Invalid UTF-8 codepoint escape sequence
+-----
+<?php $str = "\\u{xyz}";
+-----
+
+-----
+<?php $str = "\u202e";
+-----
+
+-----
+<?php $str = '\u{xyz}';
+-----
+
+-----
+<?php $str = '\\u{xyz}';
+-----
+
+-----
+<?php $str = '\u202e';
+-----

--- a/test/resource/invalidOctalLiteral/php5/invalidOctalLiteral.test
+++ b/test/resource/invalidOctalLiteral/php5/invalidOctalLiteral.test
@@ -1,4 +1,5 @@
 Invalid octal literal
+PHP <7.0
 -----
 <?php
 $i = 0781;

--- a/test/resource/invalidOctalLiteral/php7/invalidOctalLiteral.test
+++ b/test/resource/invalidOctalLiteral/php7/invalidOctalLiteral.test
@@ -1,0 +1,21 @@
+Invalid octal literal
+PHP >=7.0
+-----
+<?php
+$i = 0781;
+-----
+Invalid numeric literal
+-----
+<?php
+$i = 011119;
+-----
+Invalid numeric literal
+-----
+<?php
+$i = 01234567;
+-----
+
+-----
+<?php
+$i = 56798;
+-----


### PR DESCRIPTION
1. Added \ParseException catching to ContextChecker
2. Made Message and CheckError extend the same base class
3. Separated PHP 5 & PHP 7 versions of some tests
4. Updated documentation