### PR TITLE
Renamed Helper\NodeHelper to NodeAnalyzer\FunctionAnalyzer

### DIFF
--- a/src/Infrastructure/ContainerBuilder.php
+++ b/src/Infrastructure/ContainerBuilder.php
@@ -11,6 +11,7 @@ use Sstalle\php7cc\Helper\OSDetector;
 use Sstalle\php7cc\Helper\Path\PathHelperFactory;
 use Sstalle\php7cc\Helper\RegExp\RegExpParser;
 use Sstalle\php7cc\Lexer\ExtendedLexer;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
 use Sstalle\php7cc\NodeStatementsRemover;
 use Sstalle\php7cc\NodeTraverser\Traverser;
 use Sstalle\php7cc\PathChecker;
@@ -24,9 +25,11 @@ class ContainerBuilder
     protected $checkerVisitors = array(
         'visitor.removedFunctionCall' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\RemovedFunctionCallVisitor',
+            'dependencies' => array('nodeAnalyzer.functionAnalyzer'),
         ),
         'visitor.reservedClassName' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\ReservedClassNameVisitor',
+            'dependencies' => array('nodeAnalyzer.functionAnalyzer'),
         ),
         'visitor.duplicateFunctionParameter' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\DuplicateFunctionParameterVisitor',
@@ -42,9 +45,11 @@ class ContainerBuilder
         ),
         'visitor.funcGetArgs' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\FuncGetArgsVisitor',
+            'dependencies' => array('nodeAnalyzer.functionAnalyzer'),
         ),
         'visitor.foreach' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\ForeachVisitor',
+            'dependencies' => array('nodeAnalyzer.functionAnalyzer'),
         ),
         'visitor.invalidOctalLiteral' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\InvalidOctalLiteralVisitor',
@@ -69,7 +74,7 @@ class ContainerBuilder
         ),
         'visitor.pregReplaceEval' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\PregReplaceEvalVisitor',
-            'dependencies' => array('regExpParser'),
+            'dependencies' => array('regExpParser', 'nodeAnalyzer.functionAnalyzer'),
         ),
         'visitor.yieldExpression' => array(
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\YieldExpressionVisitor',
@@ -115,6 +120,9 @@ class ContainerBuilder
             return $traverser;
         });
 
+        $container['nodeAnalyzer.functionAnalyzer'] = $container->share(function () {
+            return new FunctionAnalyzer();
+        });
         $container['contextChecker'] = $container->share(function ($c) {
             return new ContextChecker($c['parser'], $c['lexer'], $c['traverser']);
         });

--- a/src/NodeAnalyzer/FunctionAnalyzer.php
+++ b/src/NodeAnalyzer/FunctionAnalyzer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Sstalle\php7cc\Helper;
+namespace Sstalle\php7cc\NodeAnalyzer;
 
 use PhpParser\Node;
 
-class NodeHelper
+class FunctionAnalyzer
 {
     /**
      * @param Node            $node
@@ -12,7 +12,7 @@ class NodeHelper
      *
      * @return bool
      */
-    public static function isFunctionCallByStaticName(Node $node, $checkedFunctionName)
+    public function isFunctionCallByStaticName(Node $node, $checkedFunctionName)
     {
         $isFunctionCallByStaticName = $node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name;
         if (!$isFunctionCallByStaticName) {

--- a/src/NodeVisitor/ForeachVisitor.php
+++ b/src/NodeVisitor/ForeachVisitor.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\NodeVisitor;
 
 use PhpParser\Node;
-use Sstalle\php7cc\Helper\NodeHelper;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
 
 class ForeachVisitor extends AbstractVisitor
 {
@@ -35,9 +35,16 @@ class ForeachVisitor extends AbstractVisitor
     );
 
     /**
+     * @var FunctionAnalyzer
      */
-    public function __construct()
+    protected $functionAnalyzer;
+
+    /**
+     * @param FunctionAnalyzer $functionAnalyzer
+     */
+    public function __construct(FunctionAnalyzer $functionAnalyzer)
     {
+        $this->functionAnalyzer = $functionAnalyzer;
         $this->foreachStack = new \SplStack();
         $this->arrayPointerModifyingFunctions = array_flip($this->arrayPointerModifyingFunctions);
         $this->arrayModifyingFunctions = array_flip($this->arrayModifyingFunctions);
@@ -97,7 +104,7 @@ class ForeachVisitor extends AbstractVisitor
      */
     protected function hasFunctionCallWithForeachArgument(Node $node, array $functions, $skippedByRefType = null)
     {
-        if (!NodeHelper::isFunctionCallByStaticName($node, $functions)) {
+        if (!$this->functionAnalyzer->isFunctionCallByStaticName($node, $functions)) {
             return false;
         }
 

--- a/src/NodeVisitor/FuncGetArgsVisitor.php
+++ b/src/NodeVisitor/FuncGetArgsVisitor.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\NodeVisitor;
 
 use PhpParser\Node;
-use Sstalle\php7cc\Helper\NodeHelper;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
 
 class FuncGetArgsVisitor extends AbstractVisitor
 {
@@ -25,12 +25,25 @@ class FuncGetArgsVisitor extends AbstractVisitor
     );
 
     /**
+     * @var FunctionAnalyzer
+     */
+    protected $functionAnalyzer;
+
+    /**
      * If current function's arguments could have been modified, value on top of the stack is true.
      * Otherwise false.
      *
      * @var \SplStack
      */
     protected $argumentModificationStack;
+
+    /**
+     * @param FunctionAnalyzer $functionAnalyzer
+     */
+    public function __construct(FunctionAnalyzer $functionAnalyzer)
+    {
+        $this->functionAnalyzer = $functionAnalyzer;
+    }
 
     public function beforeTraverse(array $nodes)
     {
@@ -42,7 +55,7 @@ class FuncGetArgsVisitor extends AbstractVisitor
         $isCurrentNodeFunctionLike = $node instanceof Node\FunctionLike;
         if ($isCurrentNodeFunctionLike || $this->argumentModificationStack->isEmpty()
             || !$this->argumentModificationStack->top()
-            || !NodeHelper::isFunctionCallByStaticName($node, array_flip(array('func_get_arg', 'func_get_args')))
+            || !$this->functionAnalyzer->isFunctionCallByStaticName($node, array_flip(array('func_get_arg', 'func_get_args')))
         ) {
             $isCurrentNodeFunctionLike && $this->argumentModificationStack->push(false);
 

--- a/src/NodeVisitor/PregReplaceEvalVisitor.php
+++ b/src/NodeVisitor/PregReplaceEvalVisitor.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\NodeVisitor;
 
 use PhpParser\Node;
-use Sstalle\php7cc\Helper\NodeHelper;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
 use Sstalle\php7cc\Helper\RegExp\RegExpParser;
 
 class PregReplaceEvalVisitor extends AbstractVisitor
@@ -16,16 +16,23 @@ class PregReplaceEvalVisitor extends AbstractVisitor
     protected $regExpParser;
 
     /**
-     * @param RegExpParser $regExpParser
+     * @var FunctionAnalyzer
      */
-    public function __construct(RegExpParser $regExpParser)
+    protected $functionAnalyzer;
+
+    /**
+     * @param RegExpParser     $regExpParser
+     * @param FunctionAnalyzer $functionAnalyzer
+     */
+    public function __construct(RegExpParser $regExpParser, FunctionAnalyzer $functionAnalyzer)
     {
         $this->regExpParser = $regExpParser;
+        $this->functionAnalyzer = $functionAnalyzer;
     }
 
     public function enterNode(Node $node)
     {
-        if (!NodeHelper::isFunctionCallByStaticName($node, 'preg_replace')) {
+        if (!$this->functionAnalyzer->isFunctionCallByStaticName($node, 'preg_replace')) {
             return;
         }
 

--- a/src/NodeVisitor/RemovedFunctionCallVisitor.php
+++ b/src/NodeVisitor/RemovedFunctionCallVisitor.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\NodeVisitor;
 
 use PhpParser\Node;
-use Sstalle\php7cc\Helper\NodeHelper;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
 
 class RemovedFunctionCallVisitor extends AbstractVisitor
 {
@@ -77,14 +77,23 @@ class RemovedFunctionCallVisitor extends AbstractVisitor
         'mysql_unbuffered_query',
     );
 
-    public function __construct()
+    /**
+     * @var FunctionAnalyzer
+     */
+    protected $functionAnalyzer;
+
+    /**
+     * @param FunctionAnalyzer $functionAnalyzer
+     */
+    public function __construct(FunctionAnalyzer $functionAnalyzer)
     {
+        $this->functionAnalyzer = $functionAnalyzer;
         $this->removedFunctionNames = array_flip($this->removedFunctionNames);
     }
 
     public function enterNode(Node $node)
     {
-        if (!NodeHelper::isFunctionCallByStaticName($node, $this->removedFunctionNames)) {
+        if (!$this->functionAnalyzer->isFunctionCallByStaticName($node, $this->removedFunctionNames)) {
             return;
         }
 

--- a/src/NodeVisitor/ReservedClassNameVisitor.php
+++ b/src/NodeVisitor/ReservedClassNameVisitor.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\NodeVisitor;
 
 use PhpParser\Node;
-use Sstalle\php7cc\Helper\NodeHelper;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
 
 class ReservedClassNameVisitor extends AbstractVisitor
 {
@@ -32,9 +32,16 @@ MSG;
     protected $reservedNamesToMessagesMap = array();
 
     /**
+     * @var FunctionAnalyzer
      */
-    public function __construct()
+    protected $functionAnalyzer;
+
+    /**
+     * @param FunctionAnalyzer $functionAnalyzer
+     */
+    public function __construct(FunctionAnalyzer $functionAnalyzer)
     {
+        $this->functionAnalyzer = $functionAnalyzer;
         $this->reservedNamesToMessagesMap = array_merge(
             array_fill_keys(
                 $this->reservedClassNames,
@@ -55,7 +62,7 @@ MSG;
         if ($node instanceof Node\Stmt\ClassLike) {
             $checkedName = $node->name;
             $usagePatternName = 'as a class, interface or trait name';
-        } elseif (NodeHelper::isFunctionCallByStaticName($node, 'class_alias')) {
+        } elseif ($this->functionAnalyzer->isFunctionCallByStaticName($node, 'class_alias')) {
             /** @var Node\Expr\FuncCall $node */
             $secondArgument = isset($node->args[1]) ? $node->args[1] : null;
 

--- a/test/code/ContextCheckerTest.php
+++ b/test/code/ContextCheckerTest.php
@@ -9,50 +9,11 @@ class ContextCheckerTest extends \PHPUnit_Framework_TestCase
      */
     public function testMessages($name, $code, $expectedMessages)
     {
-        $lexer = new \Sstalle\php7cc\Lexer\ExtendedLexer(array(
-            'usedAttributes' => array(
-                'comments',
-                'startLine',
-                'endLine',
-                'startTokenPos',
-                'endTokenPos',
-            ),
-        ));
-        $parser = new \PhpParser\Parser($lexer);
-        $traverser = new \Sstalle\php7cc\NodeTraverser\Traverser(false);
-        $visitors = array();
-        foreach (array(
-                     '\\Sstalle\\php7cc\\NodeVisitor\\RemovedFunctionCallVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\ReservedClassNameVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\DuplicateFunctionParameterVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\ListVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\GlobalVariableVariableVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\IndirectVariableOrMethodAccessVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\FuncGetArgsVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\ForeachVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\InvalidOctalLiteralVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\HexadecimalNumberStringVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\EscapedUnicodeCodepointVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\ArrayOrObjectValueAssignmentByReferenceVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\BitwiseShiftVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\NewAssignmentByReferenceVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\HTTPRawPostDataVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\YieldExpressionVisitor',
-                     '\\Sstalle\\php7cc\\NodeVisitor\\YieldInExpressionContextVisitor',
-                 ) as $visitorClass) {
-            $visitors[] = new $visitorClass();
-        }
-
-        $visitors[] = new \Sstalle\php7cc\NodeVisitor\PregReplaceEvalVisitor(
-            new \Sstalle\php7cc\Helper\RegExp\RegExpParser()
-        );
-
-        foreach ($visitors as $visitor) {
-            $traverser->addVisitor($visitor);
-        }
-
-        $contextChecker = new \Sstalle\php7cc\ContextChecker($parser, $lexer, $traverser);
+        $containerBuilder = new \Sstalle\php7cc\Infrastructure\ContainerBuilder();
+        $container = $containerBuilder->buildContainer(new Symfony\Component\Console\Output\NullOutput());
+        $contextChecker = $container['contextChecker'];
         $context = new \Sstalle\php7cc\CompatibilityViolation\StringContext($code, 'test');
+
         $contextChecker->checkContext($context);
         $expectedMessageCount = count($expectedMessages);
         $actualMessages = array_merge($context->getMessages(), $context->getErrors());

--- a/test/code/NodeAnalyzer/FunctionAnalyzerTest.php
+++ b/test/code/NodeAnalyzer/FunctionAnalyzerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace code\NodeAnalyzer;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Function_;
+use Sstalle\php7cc\NodeAnalyzer\FunctionAnalyzer;
+
+class FunctionAnalyzerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FunctionAnalyzer
+     */
+    protected $functionAnalyzer;
+
+    public function testIsFunctionCallByStaticNameReturnsFalseForNonFuncCallNode()
+    {
+        $node = new Function_('foo');
+        $this->assertSame($this->functionAnalyzer->isFunctionCallByStaticName($node, 'foo'), false);
+    }
+
+    public function testIsFunctionCallByStaticNameReturnsFalseForDynamicName()
+    {
+        $node = new FuncCall(new Variable('foo'));
+        $this->assertSame($this->functionAnalyzer->isFunctionCallByStaticName($node, 'foo'), false);
+    }
+
+    /**
+     * @dataProvider isFunctionCallByStaticNameChecksFunctionNameCorrectlyProvider
+     */
+    public function testIsFunctionCallByStaticNameChecksFunctionNameCorrectly($node, $checkedFunctionNames, $result)
+    {
+        $this->assertSame($this->functionAnalyzer->isFunctionCallByStaticName($node, $checkedFunctionNames), $result);
+    }
+
+    public function isFunctionCallByStaticNameChecksFunctionNameCorrectlyProvider()
+    {
+        return array(
+            array(
+                $this->buildFuncCallNodeWithStaticName('foo'),
+                'foo',
+                true,
+            ),
+            array(
+                $this->buildFuncCallNodeWithStaticName('foo'),
+                array('foo' => true),
+                true,
+            ),
+            array(
+                $this->buildFuncCallNodeWithStaticName('bar'),
+                array('foo' => true, 'bar' => true),
+                true,
+            ),
+            array(
+                $this->buildFuncCallNodeWithStaticName('foo'),
+                'bar',
+                false,
+            ),
+            array(
+                $this->buildFuncCallNodeWithStaticName('foo'),
+                array('bar' => true),
+                false,
+            ),
+            array(
+                $this->buildFuncCallNodeWithStaticName('baz'),
+                array('foo' => true, 'bar' => true),
+                false,
+            ),
+        );
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return FuncCall
+     */
+    protected function buildFuncCallNodeWithStaticName($name)
+    {
+        return new FuncCall(new Name(array($name)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->functionAnalyzer = new FunctionAnalyzer();
+    }
+}


### PR DESCRIPTION
1. Renamed Helper\NodeHelper to NodeAnalyzer\FunctionAnalyzer
2. Removed static calls to its methods, injected instance into constructor where needed