### PR TITLE
Checks new classes added in PHP7

### DIFF
--- a/src/Infrastructure/ContainerBuilder.php
+++ b/src/Infrastructure/ContainerBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Sstalle\php7cc\Infrastructure;
 
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use Sstalle\php7cc\CLIResultPrinter;
 use Sstalle\php7cc\ContextChecker;
@@ -93,6 +94,9 @@ class ContainerBuilder
             'class' => '\\Sstalle\\php7cc\\NodeVisitor\\PasswordHashSaltVisitor',
             'dependencies' => array('nodeAnalyzer.functionAnalyzer'),
         ),
+        'visitor.newClass' => array(
+            'class' => '\\Sstalle\\php7cc\\NodeVisitor\\NewClassVisitor',
+        ),
     );
 
     /**
@@ -124,6 +128,8 @@ class ContainerBuilder
         $visitors = $this->checkerVisitors;
         $container['traverser'] = $container->share(function ($c) use ($visitors) {
             $traverser = new Traverser(false);
+            // Resolve fully qualified name (class, interface, function, etc) to ease some process
+            $traverser->addVisitor(new NameResolver());
             foreach (array_keys($visitors) as $visitorServiceName) {
                 $traverser->addVisitor($c[$visitorServiceName]);
             }

--- a/src/NodeVisitor/NewClassVisitor.php
+++ b/src/NodeVisitor/NewClassVisitor.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sstalle\php7cc\NodeVisitor;
+
+use PhpParser\Node;
+
+class NewClassVisitor extends AbstractVisitor
+{
+    private static $newClasses = array(
+        'IntlChar',
+
+        'ReflectionGenerator',
+        'ReflectionType',
+
+        'SessionUpdateTimestampHandlerInterface',
+
+        'Throwable',
+        'Error',
+        'TypeError',
+        'ParseError',
+        'AssertionError',
+        'ArithmeticError',
+        'DivisionByZeroError',
+    );
+
+    private static $lowerCasedNewClasses = array();
+
+    public function __construct()
+    {
+        foreach (self::$newClasses as $className) {
+            self::$lowerCasedNewClasses[strtolower($className)] = $className;
+        }
+    }
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\ClassLike
+            && isset($node->namespacedName) // Property set by the NameResolver visitor
+            && count($node->namespacedName->parts) === 1
+            && ($lowerCasedClassName = strtolower($node->name))
+            && array_key_exists($lowerCasedClassName, self::$lowerCasedNewClasses)) {
+            $this->addContextMessage(
+                sprintf(
+                    'Class/trait/interface "%s" was added in the global namespace',
+                    self::$lowerCasedNewClasses[$lowerCasedClassName]
+                ),
+                $node
+            );
+        }
+    }
+}

--- a/test/code/ContextCheckerTest.php
+++ b/test/code/ContextCheckerTest.php
@@ -65,7 +65,7 @@ class ContextCheckerTest extends \PHPUnit_Framework_TestCase
             // multiple sections possible with always two forming a pair
             foreach (array_chunk($parts, 2) as $chunk) {
                 $messages = array_filter(explode("\n", $this->canonicalize($chunk[1])));
-                $tests[] = array($fullName, $chunk[0], $messages);
+                $tests[] = array($fullName, ltrim($chunk[0]), $messages);
             }
         }
 

--- a/test/resource/newClass/newClass.test
+++ b/test/resource/newClass/newClass.test
@@ -1,0 +1,41 @@
+New class added
+-----
+<?php
+class test {}
+-----
+
+-----
+<?php
+namespace Acme;
+interface Error {}
+-----
+
+-----
+<?php
+namespace Acme {
+    class TypeError {}
+}
+-----
+
+-----
+<?php
+class Error {}
+-----
+Class/trait/interface "Error" was added in the global namespace
+-----
+<?php
+class IntlChar {}
+-----
+Class/trait/interface "IntlChar" was added in the global namespace
+-----
+<?php
+class thrOwablE {}
+-----
+Class/trait/interface "Throwable" was added in the global namespace
+-----
+<?php
+namespace {
+    class AssertionError {}
+}
+-----
+Class/trait/interface "AssertionError" was added in the global namespace

--- a/test/resource/newClass/newClassWithTrait.test
+++ b/test/resource/newClass/newClassWithTrait.test
@@ -1,0 +1,42 @@
+New class added
+PHP >=5.4.0
+-----
+<?php
+trait test {}
+-----
+
+-----
+<?php
+namespace Acme;
+trait Error {}
+-----
+
+-----
+<?php
+namespace Acme {
+    trait TypeError {}
+}
+-----
+
+-----
+<?php
+trait Error {}
+-----
+Class/trait/interface "Error" was added in the global namespace
+-----
+<?php
+trait IntlChar {}
+-----
+Class/trait/interface "IntlChar" was added in the global namespace
+-----
+<?php
+trait thrOwablE {}
+-----
+Class/trait/interface "Throwable" was added in the global namespace
+-----
+<?php
+namespace {
+    trait AssertionError {}
+}
+-----
+Class/trait/interface "AssertionError" was added in the global namespace


### PR DESCRIPTION
This new visitor checks that a **global** class/interface/trait doesn't use the name than a class/interface added in PHP 7.