### PR TITLE
Tweak the cli output

### DIFF
--- a/src/CLIResultPrinter.php
+++ b/src/CLIResultPrinter.php
@@ -44,22 +44,28 @@ class CLIResultPrinter implements ResultPrinterInterface
     public function printContext(ContextInterface $context)
     {
         $this->output->writeln('');
-        $this->output->writeln(sprintf('File: %s', $context->getCheckedResourceName()));
+        $this->output->writeln(sprintf('File: <fg=cyan>%s</fg=cyan>', $context->getCheckedResourceName()));
 
         foreach ($context->getMessages() as $message) {
             $nodes = $this->nodeStatementsRemover->removeInnerStatements($message->getNodes());
 
             $this->output->writeln(
                 sprintf(
-                    '%s: %s',
-                    $message->getText(),
-                    $this->prettyPrinter->prettyPrint($nodes)
+                    "> Line <fg=cyan>%s</fg=cyan>: <fg=yellow>%s</fg=yellow>\n    %s",
+                    $message->getLine(),
+                    $message->getRawText(),
+                    str_replace("\n", "\n    ", $this->prettyPrinter->prettyPrint($nodes))
                 )
             );
         }
 
         foreach ($context->getErrors() as $error) {
-            $this->output->writeln($error->getText());
+            $this->output->writeln(
+                sprintf(
+                    "> <fg=red>%s</fg=red>",
+                    $error->getText()
+                )
+            );
         }
 
         $this->output->writeln('');
@@ -70,11 +76,16 @@ class CLIResultPrinter implements ResultPrinterInterface
      */
     public function printMetadata(CheckMetadata $metadata)
     {
+        $checkedFileCount = $metadata->getCheckedFileCount();
+        $elapsedTime = $metadata->getElapsedTime();
+
         $this->output->writeln(
             sprintf(
-                'Checked %d file(s) in %f second(s)',
-                $metadata->getCheckedFileCount(),
-                $metadata->getElapsedTime()
+                'Checked <fg=green>%d</fg=green> file%s in <fg=green>%.3f</fg=green> second%s',
+                $checkedFileCount,
+                $checkedFileCount > 1 ? 's' : '',
+                $elapsedTime,
+                $elapsedTime > 1 ? 's' : ''
             )
         );
     }


### PR DESCRIPTION
I propose you a small tweak of the output. Here is the difference:
Before:
![capture du 2015-08-30 00 07 40](https://cloud.githubusercontent.com/assets/2021641/9564554/2c02b702-4eab-11e5-832a-a43236d72814.png)

After:
![capture du 2015-08-30 00 06 23](https://cloud.githubusercontent.com/assets/2021641/9564555/318cc91a-4eab-11e5-844e-695a182094b1.png)


What do you think?