### PR TITLE
Updated install instructions to development only

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This makes it possible to run php7cc by entering just the executable name.
 Make sure you have composer installed. Then execute the following command from your project
 directory:
 ```bash
-composer require sstalle/php7cc
+composer require sstalle/php7cc --dev
 ```
 
 


### PR DESCRIPTION
Hi,

I updated the readme a little bit to let people install this as require-dev on their projects. These kind of tools are never required in production and shouldn't exist in production.

Regards,
Ron