### PR TITLE
Fix ReflectionException for lack of constructor

### DIFF
--- a/src/NodeVisitor/AbstractVisitor.php
+++ b/src/NodeVisitor/AbstractVisitor.php
@@ -10,6 +10,10 @@ use Sstalle\php7cc\Token\TokenCollection;
 
 abstract class AbstractVisitor extends NodeVisitorAbstract implements VisitorInterface
 {
+    public function __construct()
+    {
+    }
+    
     /**
      * @var ContextInterface
      */


### PR DESCRIPTION
I get ReflectionExceptions running php7cc on any file or directory, e.g.
Class Sstalle\php7cc\NodeVisitor\GlobalVariableVariableVisitor does not have a constructor, so you cannot pass any constructor arguments

This seems to happen with every single class in that directory so patching the base class seems easier.