### PR TITLE
Don't break on anonymous classes

### DIFF
--- a/src/NodeVisitor/PHP4ConstructorVisitor.php
+++ b/src/NodeVisitor/PHP4ConstructorVisitor.php
@@ -14,6 +14,11 @@ class PHP4ConstructorVisitor extends AbstractVisitor
             $hasPhp5Constructor = false;
             $php4ConstructorNode = null;
 
+            // Anonymous class can't use php4 constructor by definition
+            if (empty($currentClassName)) {
+                return;
+            }
+
             // Checks if class is namespaced (property namespacedName was set by the NameResolver visitor)
             if (count($node->namespacedName->parts) > 1) {
                 return;

--- a/test/code/NodeVisitor/PHP4ConstructorVisitorTest.php
+++ b/test/code/NodeVisitor/PHP4ConstructorVisitorTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace code\NodeVisitor;
+
+use PHPUnit_Framework_TestCase;
+use Sstalle\php7cc\NodeVisitor\PHP4ConstructorVisitor;
+
+/**
+ * Unit test for the PHP4 constructor visitor
+ *
+ * @author Ron Rademaker
+ */
+class PHP4ConstructorVisitorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test if an anonymous class is dealt with correctly
+     */
+    public function testAnonymousClassIsValid()
+    {
+        $visitor = new PHP4ConstructorVisitor();
+
+        $node = $this->getMockBuilder('PhpParser\Node\Stmt\Class_')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // triggers a notice that it shouldn't
+        $visitor->enterNode($node);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Hi,

I was scanning my project and php7cc triggered notices on parts of phpunit. I traced it down to vendor/phpunit/php-token-stream/tests/_fixture/class_with_method_that_declares_anonymous_class.php, where anonymous classes are used. This broke on the PHP4 constructor test, obviously it's impossible for an anonymous class to use a PHP4 constructor. 

I've added a check for this to prevent these notices.

Regards,
Ron

The notice:

```
PHP Notice:  Undefined property: PhpParser\Node\Stmt\Class_::$namespacedName in /Users/ron/.composer/vendor/sstalle/php7cc/src/NodeVisitor/PHP4ConstructorVisitor.php on line 18
PHP Stack trace:
PHP   1. {main}() /Users/ron/.composer/vendor/sstalle/php7cc/bin/php7cc:0
PHP   2. require() /Users/ron/.composer/vendor/sstalle/php7cc/bin/php7cc:4
PHP   3. Symfony\Component\Console\Application->run() /Users/ron/.composer/vendor/sstalle/php7cc/bin/php7cc.php:21
PHP   4. Symfony\Component\Console\Application->doRun() /Users/ron/.composer/vendor/symfony/console/Application.php:123
PHP   5. Symfony\Component\Console\Application->doRunCommand() /Users/ron/.composer/vendor/symfony/console/Application.php:192
PHP   6. Symfony\Component\Console\Command\Command->run() /Users/ron/.composer/vendor/symfony/console/Application.php:841
PHP   7. Sstalle\php7cc\Infrastructure\PHP7CCCommand->execute() /Users/ron/.composer/vendor/symfony/console/Command/Command.php:259
PHP   8. Sstalle\php7cc\PathCheckExecutor->check() /Users/ron/.composer/vendor/sstalle/php7cc/src/Infrastructure/PHP7CCCommand.php:76
PHP   9. Sstalle\php7cc\PathChecker->check() /Users/ron/.composer/vendor/sstalle/php7cc/src/PathCheckExecutor.php:35
PHP  10. Sstalle\php7cc\PathChecker->checkFile() /Users/ron/.composer/vendor/sstalle/php7cc/src/PathChecker.php:48
PHP  11. Sstalle\php7cc\ContextChecker->checkContext() /Users/ron/.composer/vendor/sstalle/php7cc/src/PathChecker.php:63
PHP  12. Sstalle\php7cc\NodeTraverser\Traverser->traverse() /Users/ron/.composer/vendor/sstalle/php7cc/src/ContextChecker.php:50
PHP  13. PhpParser\NodeTraverser->traverse() /Users/ron/.composer/vendor/sstalle/php7cc/src/NodeTraverser/Traverser.php:26
PHP  14. PhpParser\NodeTraverser->traverseArray() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:64
PHP  15. PhpParser\NodeTraverser->traverseNode() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:129
PHP  16. PhpParser\NodeTraverser->traverseArray() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:84
PHP  17. PhpParser\NodeTraverser->traverseNode() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:129
PHP  18. PhpParser\NodeTraverser->traverseArray() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:84
PHP  19. PhpParser\NodeTraverser->traverseNode() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:129
PHP  20. PhpParser\NodeTraverser->traverseNode() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:97
PHP  21. Sstalle\php7cc\NodeVisitor\PHP4ConstructorVisitor->enterNode() /Users/ron/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:88
```