### PR TITLE
Remove useless property

### DIFF
--- a/src/NodeVisitor/DuplicateFunctionParameterVisitor.php
+++ b/src/NodeVisitor/DuplicateFunctionParameterVisitor.php
@@ -7,11 +7,6 @@ use PhpParser\Node;
 class DuplicateFunctionParameterVisitor extends AbstractVisitor
 {
     /**
-     * @var Node|null
-     */
-    protected $currentFunction;
-
-    /**
      * {@inheritdoc}
      */
     public function enterNode(Node $node)


### PR DESCRIPTION
The property `DuplicateFunctionParameterVisitor#currentFunction` is not used so I guess it can be removed :wink: 