### PR TITLE
Differentiate errors from possible warnings

### DIFF
--- a/src/CLIResultPrinter.php
+++ b/src/CLIResultPrinter.php
@@ -5,9 +5,16 @@ namespace Sstalle\php7cc;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use Sstalle\php7cc\CompatibilityViolation\CheckMetadata;
 use Sstalle\php7cc\CompatibilityViolation\ContextInterface;
+use Sstalle\php7cc\CompatibilityViolation\Message;
 
 class CLIResultPrinter implements ResultPrinterInterface
 {
+    private static $colors = array(
+        Message::LEVEL_INFO => null,
+        Message::LEVEL_WARNING => 'yellow',
+        Message::LEVEL_ERROR => 'red',
+    );
+
     /**
      * @var CLIOutputInterface
      */
@@ -47,15 +54,8 @@ class CLIResultPrinter implements ResultPrinterInterface
         $this->output->writeln(sprintf('File: <fg=cyan>%s</fg=cyan>', $context->getCheckedResourceName()));
 
         foreach ($context->getMessages() as $message) {
-            $nodes = $this->nodeStatementsRemover->removeInnerStatements($message->getNodes());
-
             $this->output->writeln(
-                sprintf(
-                    "> Line <fg=cyan>%s</fg=cyan>: <fg=yellow>%s</fg=yellow>\n    %s",
-                    $message->getLine(),
-                    $message->getRawText(),
-                    str_replace("\n", "\n    ", $this->prettyPrinter->prettyPrint($nodes))
-                )
+                $this->formatMessage($message)
             );
         }
 
@@ -88,5 +88,37 @@ class CLIResultPrinter implements ResultPrinterInterface
                 $elapsedTime > 1 ? 's' : ''
             )
         );
+    }
+
+    /**
+     * @param Message $message
+     *
+     * @return string
+     */
+    private function formatMessage(Message $message)
+    {
+        $nodes = $this->nodeStatementsRemover->removeInnerStatements($message->getNodes());
+        $prettyPrintedNodes = str_replace("\n", "\n    ", $this->prettyPrinter->prettyPrint($nodes));
+
+        $text = $message->getRawText();
+        $color = self::$colors[$message->getLevel()];
+
+        if ($color) {
+            $text = sprintf(
+                '<fg=%s>%s</fg=%s>',
+                $color,
+                $text,
+                $color
+            );
+        }
+
+        return sprintf(
+            "> Line <fg=cyan>%s</fg=cyan>: %s\n    %s",
+            $message->getLine(),
+            $text,
+            $prettyPrintedNodes
+        );
+
+        return $string;
     }
 }

--- a/src/CompatibilityViolation/Message.php
+++ b/src/CompatibilityViolation/Message.php
@@ -7,6 +7,15 @@ use Sstalle\php7cc\AbstractBaseMessage;
 
 class Message extends AbstractBaseMessage
 {
+    const LEVEL_INFO = 0;
+    const LEVEL_WARNING = 1;
+    const LEVEL_ERROR = 2;
+
+    /**
+     * @var int
+     */
+    protected $level;
+
     /**
      * @var Node[]
      */
@@ -15,12 +24,22 @@ class Message extends AbstractBaseMessage
     /**
      * @param string   $text
      * @param int|null $line
+     * @param int      $level
      * @param Node[]   $nodes
      */
-    public function __construct($text, $line = null, array $nodes = array())
+    public function __construct($text, $line = null, $level = self::LEVEL_INFO, array $nodes = array())
     {
         parent::__construct($text, $line);
+        $this->level = $level;
         $this->nodes = $nodes;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevel()
+    {
+        return $this->level;
     }
 
     /**

--- a/src/NodeVisitor/AbstractVisitor.php
+++ b/src/NodeVisitor/AbstractVisitor.php
@@ -39,8 +39,27 @@ abstract class AbstractVisitor extends NodeVisitorAbstract implements VisitorInt
      * @param string $text
      * @param Node   $node
      */
-    protected function addContextMessage($text, Node $node)
+    protected function addContextWarning($text, Node $node)
     {
-        $this->context->addMessage(new Message($text, $node->getAttribute('startLine'), array($node)));
+        $this->addContextMessage($text, $node, Message::LEVEL_WARNING);
+    }
+
+    /**
+     * @param string $text
+     * @param Node   $node
+     */
+    protected function addContextError($text, Node $node)
+    {
+        $this->addContextMessage($text, $node, Message::LEVEL_ERROR);
+    }
+
+    /**
+     * @param string $text
+     * @param Node   $node
+     * @param int    $level
+     */
+    private function addContextMessage($text, Node $node, $level)
+    {
+        $this->context->addMessage(new Message($text, $node->getAttribute('startLine'), $level, array($node)));
     }
 }

--- a/src/NodeVisitor/ArrayOrObjectValueAssignmentByReferenceVisitor.php
+++ b/src/NodeVisitor/ArrayOrObjectValueAssignmentByReferenceVisitor.php
@@ -25,7 +25,7 @@ class ArrayOrObjectValueAssignmentByReferenceVisitor extends AbstractVisitor
         if ($node->var instanceof Node\Expr\ArrayDimFetch && $node->var->dim
             && $node->expr instanceof Node\Expr\ArrayDimFetch && $node->expr->dim
         ) {
-            $this->addContextMessage(
+            $this->addContextWarning(
                 'Possible array element creation during by-reference assignment',
                 $node
             );
@@ -44,7 +44,7 @@ class ArrayOrObjectValueAssignmentByReferenceVisitor extends AbstractVisitor
     protected function checkObjectPropertyByReferenceCreation(Node\Expr\AssignRef $node)
     {
         if ($node->var instanceof Node\Expr\PropertyFetch && $node->expr instanceof Node\Expr\PropertyFetch) {
-            $this->addContextMessage(
+            $this->addContextWarning(
                 'Possible object property creation during by-reference assignment',
                 $node
             );

--- a/src/NodeVisitor/BitwiseShiftVisitor.php
+++ b/src/NodeVisitor/BitwiseShiftVisitor.php
@@ -20,12 +20,12 @@ class BitwiseShiftVisitor extends AbstractVisitor
         if ($rightOperand instanceof Node\Expr\UnaryMinus && $rightOperand->expr instanceof Node\Scalar\LNumber
             && $rightOperand->expr->value > 0
         ) {
-            $this->addContextMessage(
+            $this->addContextError(
                 'Bitwise shift by a negative number',
                 $node
             );
         } elseif ($rightOperand instanceof Node\Scalar\LNumber && $rightOperand->value >= static::MIN_INT_SIZE) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf('Bitwise shift by %d bits', $rightOperand->value),
                 $node
             );

--- a/src/NodeVisitor/DivisionModuloByZeroVisitor.php
+++ b/src/NodeVisitor/DivisionModuloByZeroVisitor.php
@@ -17,7 +17,7 @@ class DivisionModuloByZeroVisitor extends AbstractVisitor
 
         $divisor = $node instanceof Node\Expr\BinaryOp ? $node->right : $node->expr;
         if ($divisor instanceof Node\Scalar\LNumber && $divisor->value == 0) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf('%s by zero', $isDivision ? 'Division' : 'Modulo'),
                 $node
             );

--- a/src/NodeVisitor/DuplicateFunctionParameterVisitor.php
+++ b/src/NodeVisitor/DuplicateFunctionParameterVisitor.php
@@ -21,7 +21,7 @@ class DuplicateFunctionParameterVisitor extends AbstractVisitor
             if (!isset($parametersNames[$currentParameterName])) {
                 $parametersNames[$currentParameterName] = false;
             } elseif (!$parametersNames[$currentParameterName]) {
-                $this->addContextMessage(
+                $this->addContextError(
                     sprintf('Duplicate function parameter name "%s"', $currentParameterName),
                     $node
                 );

--- a/src/NodeVisitor/EscapedUnicodeCodepointVisitor.php
+++ b/src/NodeVisitor/EscapedUnicodeCodepointVisitor.php
@@ -29,7 +29,7 @@ class EscapedUnicodeCodepointVisitor extends AbstractVisitor
 
         $matches = array();
         if (preg_match('/((?<!\\\\)\\\\u{.*})/', $unquotedStringValue, $matches)) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf('Unicode codepoint escaping "%s" in a string', $matches[0]),
                 $node
             );

--- a/src/NodeVisitor/ForeachVisitor.php
+++ b/src/NodeVisitor/ForeachVisitor.php
@@ -75,7 +75,7 @@ class ForeachVisitor extends AbstractVisitor
     protected function checkInternalArrayPointerAccessInByValueForeach(Node $node)
     {
         if ($this->hasFunctionCallWithForeachArgument($node, $this->arrayPointerModifyingFunctions, true)) {
-            $this->addContextMessage(
+            $this->addContextWarning(
                 'Possible internal array pointer access/modification in a by-value foreach loop',
                 $node
             );
@@ -88,7 +88,7 @@ class ForeachVisitor extends AbstractVisitor
     protected function checkArrayModificationByFunctionInByReferenceForeach(Node $node)
     {
         if ($this->hasFunctionCallWithForeachArgument($node, $this->arrayModifyingFunctions, false)) {
-            $this->addContextMessage(
+            $this->addContextWarning(
                 'Possible array modification using internal function in a by-reference foreach loop',
                 $node
             );
@@ -145,7 +145,7 @@ class ForeachVisitor extends AbstractVisitor
             }
 
             if ($node->var->var->name === $this->getForeachVariableName($foreach)) {
-                $this->addContextMessage(
+                $this->addContextWarning(
                     'Possible adding to array on the last iteration of a by-reference foreach loop',
                     $node
                 );
@@ -162,7 +162,7 @@ class ForeachVisitor extends AbstractVisitor
         /** @var Node\Stmt\Foreach_ $ancestorForeach */
         foreach ($this->foreachStack as $ancestorForeach) {
             if ($ancestorForeach->byRef) {
-                $this->addContextMessage(
+                $this->addContextWarning(
                     'Nested by-reference foreach loop, make sure there is no iteration over the same array',
                     $foreach
                 );

--- a/src/NodeVisitor/FuncGetArgsVisitor.php
+++ b/src/NodeVisitor/FuncGetArgsVisitor.php
@@ -64,7 +64,7 @@ class FuncGetArgsVisitor extends AbstractVisitor
 
         /** @var Node\Expr\FuncCall $node */
         $functionName = $node->name->toString();
-        $this->addContextMessage(
+        $this->addContextWarning(
             sprintf('Function argument(s) returned by "%s" might have been modified', $functionName),
             $node
         );

--- a/src/NodeVisitor/GlobalVariableVariableVisitor.php
+++ b/src/NodeVisitor/GlobalVariableVariableVisitor.php
@@ -30,7 +30,7 @@ class GlobalVariableVariableVisitor extends AbstractVisitor
                 continue;
             }
 
-            $this->addContextMessage(
+            $this->addContextError(
                 'Complex variable without curly braces in global keyword',
                 $node
             );

--- a/src/NodeVisitor/HTTPRawPostDataVisitor.php
+++ b/src/NodeVisitor/HTTPRawPostDataVisitor.php
@@ -19,7 +19,7 @@ class HTTPRawPostDataVisitor extends AbstractVisitor
             && $node->dim->value === static::HTTP_RAW_POST_DATA_VARIABLE_NAME;
 
         if ($isVariableAccessedByName || $isVariableAccessedThroughGlobals) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf(
                     'Removed "%s" variable used',
                     static::HTTP_RAW_POST_DATA_VARIABLE_NAME

--- a/src/NodeVisitor/HexadecimalNumberStringVisitor.php
+++ b/src/NodeVisitor/HexadecimalNumberStringVisitor.php
@@ -13,7 +13,7 @@ class HexadecimalNumberStringVisitor extends AbstractVisitor
         }
 
         if (preg_match('/^0x[a-fA-F0-9]+$/', $node->value)) {
-            $this->addContextMessage(
+            $this->addContextError(
                 'String containing number in hexadecimal notation',
                 $node
             );

--- a/src/NodeVisitor/IndirectVariableOrMethodAccessVisitor.php
+++ b/src/NodeVisitor/IndirectVariableOrMethodAccessVisitor.php
@@ -24,7 +24,7 @@ class IndirectVariableOrMethodAccessVisitor extends AbstractVisitor
             return;
         }
 
-        $this->addContextMessage(
+        $this->addContextWarning(
             'Indirect variable, property or method access',
             $node
         );

--- a/src/NodeVisitor/InvalidOctalLiteralVisitor.php
+++ b/src/NodeVisitor/InvalidOctalLiteralVisitor.php
@@ -15,7 +15,7 @@ class InvalidOctalLiteralVisitor extends AbstractVisitor
         $originalNumberValue = $node->getAttribute('originalValue', '');
 
         if (preg_match('/^0[0-7]*[89]+/', $originalNumberValue)) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf('Invalid octal literal %s', $originalNumberValue),
                 $node
             );

--- a/src/NodeVisitor/ListVisitor.php
+++ b/src/NodeVisitor/ListVisitor.php
@@ -18,7 +18,7 @@ class ListVisitor extends AbstractVisitor
             }
 
             if (!$hasNonNullVar) {
-                $this->addContextMessage(
+                $this->addContextError(
                     'Empty list assignment',
                     $node
                 );
@@ -28,7 +28,7 @@ class ListVisitor extends AbstractVisitor
         if ($node instanceof Node\Expr\Assign && $node->var instanceof Node\Expr\List_
             && ($node->expr instanceof Node\Scalar\String_ || $node->expr instanceof Node\Expr\Cast\String_)
         ) {
-            $this->addContextMessage(
+            $this->addContextError(
                 'list unpacking string',
                 $node
             );

--- a/src/NodeVisitor/MktimeVisitor.php
+++ b/src/NodeVisitor/MktimeVisitor.php
@@ -34,7 +34,7 @@ class MktimeVisitor extends AbstractVisitor
             return;
         }
 
-        $this->addContextMessage(
+        $this->addContextError(
             sprintf('Removed argument $is_dst used for function "%s"', $node->name->__toString()),
             $node
         );

--- a/src/NodeVisitor/MultipleSwitchDefaultsVisitor.php
+++ b/src/NodeVisitor/MultipleSwitchDefaultsVisitor.php
@@ -20,7 +20,7 @@ class MultipleSwitchDefaultsVisitor extends AbstractVisitor
         }
 
         if ($defaultCaseCount > 1) {
-            $this->addContextMessage(
+            $this->addContextError(
                 'Multiple default cases defined for the switch statement',
                 $node
             );

--- a/src/NodeVisitor/NewAssignmentByReferenceVisitor.php
+++ b/src/NodeVisitor/NewAssignmentByReferenceVisitor.php
@@ -9,7 +9,7 @@ class NewAssignmentByReferenceVisitor extends AbstractVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Expr\AssignRef && $node->expr instanceof Node\Expr\New_) {
-            $this->addContextMessage(
+            $this->addContextError(
                 'Result of new is assigned by reference',
                 $node
             );

--- a/src/NodeVisitor/NewClassVisitor.php
+++ b/src/NodeVisitor/NewClassVisitor.php
@@ -39,7 +39,7 @@ class NewClassVisitor extends AbstractVisitor
             && count($node->namespacedName->parts) === 1
             && ($lowerCasedClassName = strtolower($node->name))
             && array_key_exists($lowerCasedClassName, self::$lowerCasedNewClasses)) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf(
                     'Class/trait/interface "%s" was added in the global namespace',
                     self::$lowerCasedNewClasses[$lowerCasedClassName]

--- a/src/NodeVisitor/NewFunctionVisitor.php
+++ b/src/NodeVisitor/NewFunctionVisitor.php
@@ -41,7 +41,7 @@ class NewFunctionVisitor extends AbstractVisitor
             && ($lowerCasedFunction = strtolower($node->name))
             && array_key_exists($lowerCasedFunction, self::$lowerCasedNewFunctions)) {
             if (isset($node->namespacedName) && count($node->namespacedName->parts) === 1) {
-                $this->addContextMessage(
+                $this->addContextError(
                     sprintf(
                         'Cannot redeclare global function "%s"',
                         self::$lowerCasedNewFunctions[$lowerCasedFunction]
@@ -49,7 +49,7 @@ class NewFunctionVisitor extends AbstractVisitor
                     $node
                 );
             } else {
-                $this->addContextMessage(
+                $this->addContextWarning(
                     sprintf(
                         'Your namespaced function "%s" could replace the new global function added in PHP 7',
                         self::$lowerCasedNewFunctions[$lowerCasedFunction]

--- a/src/NodeVisitor/PHP4ConstructorVisitor.php
+++ b/src/NodeVisitor/PHP4ConstructorVisitor.php
@@ -39,7 +39,7 @@ class PHP4ConstructorVisitor extends AbstractVisitor
             }
 
             if ($hasPhp4Constructor && !$hasPhp5Constructor) {
-                $this->addContextMessage(
+                $this->addContextError(
                     'PHP 4 constructors are now deprecated',
                     $php4ConstructorNode
                 );

--- a/src/NodeVisitor/PasswordHashSaltVisitor.php
+++ b/src/NodeVisitor/PasswordHashSaltVisitor.php
@@ -36,7 +36,7 @@ class PasswordHashSaltVisitor extends AbstractVisitor
         /** @var $node Node\Expr\FuncCall */
         foreach ($passwordHashOptions->items as $option) {
             if ($option->key instanceof Node\Scalar\String_ && $option->key->value === 'salt') {
-                $this->addContextMessage(
+                $this->addContextError(
                     'Deprecated option "salt" passed to password_hash function',
                     $node
                 );

--- a/src/NodeVisitor/PregReplaceEvalVisitor.php
+++ b/src/NodeVisitor/PregReplaceEvalVisitor.php
@@ -44,7 +44,7 @@ class PregReplaceEvalVisitor extends AbstractVisitor
 
         $regExp = $this->regExpParser->parse($regExpPatternArgument->value->value);
         if ($regExp->hasModifier(static::PREG_REPLACE_EVAL_MODIFIER)) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf('Removed regular expression modifier "%s" used', static::PREG_REPLACE_EVAL_MODIFIER),
                 $node
             );

--- a/src/NodeVisitor/RemovedFunctionCallVisitor.php
+++ b/src/NodeVisitor/RemovedFunctionCallVisitor.php
@@ -153,7 +153,7 @@ class RemovedFunctionCallVisitor extends AbstractVisitor
         }
 
         /** @var Node\Expr\FuncCall $node */
-        $this->addContextMessage(
+        $this->addContextError(
             sprintf('Removed function "%s" called', $node->name->toString()),
             $node
         );

--- a/src/NodeVisitor/ReservedClassNameVisitor.php
+++ b/src/NodeVisitor/ReservedClassNameVisitor.php
@@ -79,7 +79,7 @@ MSG;
 
         $checkedName = strtolower($checkedName);
         if ($checkedName && isset($this->reservedNamesToMessagesMap[$checkedName])) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf($this->reservedNamesToMessagesMap[$checkedName], $checkedName, $usagePatternName),
                 $node
             );

--- a/src/NodeVisitor/SessionSetSaveHandlerVisitor.php
+++ b/src/NodeVisitor/SessionSetSaveHandlerVisitor.php
@@ -23,7 +23,7 @@ class SessionSetSaveHandlerVisitor extends AbstractVisitor
     public function enterNode(Node $node)
     {
         if ($this->functionAnalyzer->isFunctionCallByStaticName($node, array('session_set_save_handler' => true))) {
-            $this->addContextMessage(
+            $this->addContextWarning(
                 'Check that callbacks that are passed to "session_set_save_handler" '
                 . 'and return false or -1 (if any) operate correctly',
                 $node

--- a/src/NodeVisitor/SetcookieEmptyNameVisitor.php
+++ b/src/NodeVisitor/SetcookieEmptyNameVisitor.php
@@ -42,7 +42,7 @@ class SetcookieEmptyNameVisitor extends AbstractVisitor
             && in_array(strtolower($cookieNameArgumentValue->name->toString()), array('null', 'false'), true);
 
         if ($isEmptyConstant || $isEmptyString) {
-            $this->addContextMessage(
+            $this->addContextError(
                 sprintf('Function "%s" called with an empty cookie name', $node->name->toString()),
                 $node
             );

--- a/src/NodeVisitor/YieldExpressionVisitor.php
+++ b/src/NodeVisitor/YieldExpressionVisitor.php
@@ -25,7 +25,7 @@ class YieldExpressionVisitor extends AbstractVisitor
 
         $valueClass = get_class($node->value);
         if (isset($this->lowerPrecedenceExpressionClasses[$valueClass])) {
-            $this->addContextMessage(
+            $this->addContextWarning(
                 'Yielding expression with precedence lower than "yield"',
                 $node
             );

--- a/src/NodeVisitor/YieldInExpressionContextVisitor.php
+++ b/src/NodeVisitor/YieldInExpressionContextVisitor.php
@@ -28,7 +28,7 @@ class YieldInExpressionContextVisitor extends AbstractVisitor
                 )
                 && !$this->expressionStack->isEmpty()
             ) {
-                $this->addContextMessage(
+                $this->addContextError(
                     '"yield" usage in expression context',
                     $this->expressionStack->top()
                 );


### PR DESCRIPTION
Currently php7cc can output a lot of "warning" (like "foreach" with reference, etc) that are only **possible** incompatibilities but which are rendered the same way than real "errors". So I propose you to introduce two others kind of messages: `Warning` and `Error` that both extends `Message` (to keep the changes small).

Warnings are still displayed in yellow but errors are now rendered in red.
Simple `Message` have been kept (all existing messages have been converted to either `Warning` or `Error`, but could be useful in the future) and will be rendered without any style.

I am not sure about the conversion of some incompatibilities so please let me know if something doesn't look good to you.

![demo](https://cloud.githubusercontent.com/assets/2021641/13411750/490950a2-df3f-11e5-8260-97f04e715e4f.png)
