### PR TITLE
fix level parameter documentation

### DIFF
--- a/src/Infrastructure/PHP7CCCommand.php
+++ b/src/Infrastructure/PHP7CCCommand.php
@@ -67,7 +67,7 @@ class PHP7CCCommand extends Command
                 static::MESSAGE_LEVEL_OPTION_NAME,
                 'l',
                 InputOption::VALUE_REQUIRED,
-                'Only show messages having this or higher severity level (can be info, message or warning)',
+                'Only show messages having this or higher severity level (can be info, warning or error)',
                 'info'
             )->addOption(
                 static::RELATIVE_PATHS_OPTION_NAME,


### PR DESCRIPTION
Documentation for level parameter is wrong. The value `message` is not handle and should be replaced by `error`

Command and result : 
```
php711 php7cc.phar --level=message .
Unknown message level message
```

Command and result : 
```
php711 php7cc.phar --level=error .
Checked 0 file in 0.029 second
```