### PR TITLE
Updated PHP Parser from 1.4 to 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
     - "$HOME/.composer/cache"
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,15 @@
     }
   },
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.5",
     "symfony/console": "~2.3 || ~3.0",
     "symfony/finder": "~2.3 || ~3.0",
     "pimple/pimple": "~3.0",
-    "nikic/php-parser": "~1.4",
+    "nikic/php-parser": "~3.1",
     "bcncommerce/json-stream": "0.3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.7.*",
+    "phpunit/phpunit": "^4.8",
     "mikey179/vfsStream": "~1.5",
     "friendsofphp/php-cs-fixer": "~1.10"
   },

--- a/src/Infrastructure/ContainerBuilder.php
+++ b/src/Infrastructure/ContainerBuilder.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\Infrastructure;
 
 use PhpParser\NodeVisitor\NameResolver;
-use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use Pimple\Container;
 use Sstalle\php7cc\CLIResultPrinter;
 use Sstalle\php7cc\ContextChecker;
@@ -167,7 +167,7 @@ class ContainerBuilder
             ));
         };
         $container['parser'] = function ($c) {
-            return new Parser($c['lexer']);
+            return (new ParserFactory())->create(ParserFactory::PREFER_PHP5, $c['lexer']);
         };
 
         $this->addVisitors($container);

--- a/src/Lexer/ExtendedLexer.php
+++ b/src/Lexer/ExtendedLexer.php
@@ -3,7 +3,7 @@
 namespace Sstalle\php7cc\Lexer;
 
 use PhpParser\Lexer;
-use PhpParser\Parser;
+use PhpParser\Parser\Tokens;
 
 class ExtendedLexer extends Lexer\Emulative
 {
@@ -14,19 +14,19 @@ class ExtendedLexer extends Lexer\Emulative
     {
         $tokenId = parent::getNextToken($value, $startAttributes, $endAttributes);
 
-        if ($tokenId == Parser::T_CONSTANT_ENCAPSED_STRING // non-interpolated string
-            || $tokenId == Parser::T_LNUMBER               // integer
-            || $tokenId == Parser::T_DNUMBER               // floating point number
+        if ($tokenId == Tokens::T_CONSTANT_ENCAPSED_STRING // non-interpolated string
+            || $tokenId == Tokens::T_LNUMBER               // integer
+            || $tokenId == Tokens::T_DNUMBER               // floating point number
         ) {
             // could also use $startAttributes, doesn't really matter here
             $endAttributes['originalValue'] = $value;
         }
 
-        if ($tokenId == Parser::T_CONSTANT_ENCAPSED_STRING) {
+        if ($tokenId == Tokens::T_CONSTANT_ENCAPSED_STRING) {
             $endAttributes['isDoubleQuoted'] = $value[0] === '"';
         }
 
-        if ($tokenId == Parser::T_END_HEREDOC) {
+        if ($tokenId == Tokens::T_END_HEREDOC) {
             $endAttributes['isHereDoc'] = true;
         }
 

--- a/src/NodeVisitor/FuncGetArgsVisitor.php
+++ b/src/NodeVisitor/FuncGetArgsVisitor.php
@@ -134,8 +134,9 @@ class FuncGetArgsVisitor extends AbstractVisitor
                 return $modifiedNames;
 
             case $node instanceof Node\Stmt\Global_:
-            case $node instanceof Node\Expr\List_:
                 return $this->extractModifiedVariableNames($node->vars);
+            case $node instanceof Node\Expr\List_:
+                return $this->extractModifiedVariableNames($node->items);
 
             case $node instanceof Node\Expr\Assign:
             case $node instanceof Node\Expr\AssignOp:
@@ -263,6 +264,10 @@ class FuncGetArgsVisitor extends AbstractVisitor
 
             if ($node instanceof Node\Expr\ArrayDimFetch) {
                 $variableNameNode = $node->var;
+            }
+
+            if ($node instanceof Node\Expr\ArrayItem) {
+                $variableNameNode = $node->value;
             }
 
             if (!($variableNameNode instanceof Node\Expr\Variable)) {

--- a/src/NodeVisitor/ListVisitor.php
+++ b/src/NodeVisitor/ListVisitor.php
@@ -16,7 +16,7 @@ class ListVisitor extends AbstractVisitor
     {
         if ($node instanceof Node\Expr\List_) {
             $hasNonNullVar = false;
-            foreach ($node->vars as $var) {
+            foreach ($node->items as $var) {
                 if ($var !== null) {
                     $hasNonNullVar = true;
                     break;

--- a/test/code/NodeStatementsRemoveTest.php
+++ b/test/code/NodeStatementsRemoveTest.php
@@ -51,4 +51,9 @@ class NodeStatementsRemoveTest extends \PHPUnit_Framework_TestCase
 class Node extends NodeAbstract
 {
     public $stmts;
+
+    public function getSubNodeNames()
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
- Migrated from PHP Parser 1.4 to PHP Parser 2.1

Applied https://github.com/nikic/PHP-Parser/blob/v3.1.1/UPGRADE-2.0.md

Tried non breaking approach using PREFER_PHP5.
Everything works.

- Migrated from PHP Parser 2.1 to PHP Parser 3.1

Applied https://github.com/nikic/PHP-Parser/blob/v3.1.1/UPGRADE-3.0.md

Dropped the support for older versions of PHP, as PHP Parser v3.1 requires 5.5+.
Removed older PHP versions from CI
Reformatted code to CS